### PR TITLE
bugfix/67284 - remove all_products reference to avoid reaching usage limit

### DIFF
--- a/src/snippets/product-card-slider.liquid
+++ b/src/snippets/product-card-slider.liquid
@@ -67,7 +67,7 @@
             {% assign bs = block.settings %}
             <div class="swiper-slide" data-card-slide {{block.shopify_attributes}}>
               {% render 'product-card'
-                card_product: all_products[bs.card_product],
+                card_product: bs.card_product,
                 color: bs.selected_color
               %}
             </div>


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
