### PR TITLE
bugfix/78921 - Homepage carousel product cards redirecting to the wrong color

### DIFF
--- a/src/snippets/product-card.liquid
+++ b/src/snippets/product-card.liquid
@@ -87,7 +87,7 @@
 
 {% if card_product != blank %}
   <div id="product-card-{{ card_product.id }}" class="product-card {{ card_classes }}" data-product-card>
-    <a href="{{card_product.url}}?variant={{current_variant.id}}" class="product-card__gallery" data-gallery-slider data-product-url="{{card_product.url}}?variant={{current_variant.id}}">
+    <a href="{{card_product.url}}?variant={{current_variant.id}}" class="product-card__gallery" data-gallery-slider data-product-url="{{card_product.url}}">
       {{ card_images }}
     </a>
     <form target="/cart/add" class="product-card__content text-center">


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
