### PR TITLE
task/43722 - Added half filled star to yotpo styles

### DIFF
--- a/src/_styles/components/yotpo.scss
+++ b/src/_styles/components/yotpo.scss
@@ -6,7 +6,7 @@
 
 // These variables should be defined in variables.scss.liquid but need to default to `false` in order for our conditional logic to work
 $yotpo-icon-star: 'yotpo-full-star.svg';
-$yotpo-icon-star-half: 'yotpo-empty-star.svg';
+$yotpo-icon-star-half: 'yotpo-half-star.svg';
 $yotpo-icon-star-empty:  'yotpo-empty-star.svg';
 
 @import 'yotpo/rating-stars';

--- a/src/assets/yotpo-half-star.svg
+++ b/src/assets/yotpo-half-star.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns:serif="http://www.serif.com/"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 720 720"
+	 style="enable-background:new 0 0 720 720;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#121212;stroke-width:43.2;stroke-miterlimit:28.8;}
+	.st1{fill:#121212;}
+</style>
+<g transform="matrix(1,0,0,1,12,11)">
+	<g>
+		<path class="st0" d="M614.4,281.7H409.5L344.4,75.2l-65.1,206.5H74.4l174.7,127l-79.4,206.5l174.7-127.1l174.7,127.1l-79.4-206.5
+			L614.4,281.7z"/>
+	</g>
+</g>
+<g>
+	<path class="st1" d="M978.5,626.2"/>
+	<path class="st1" d="M883.2,292.7"/>
+</g>
+<polygon class="st1" points="356.8,86.8 356.4,499.2 182.1,626.8 261.5,420.3 86.8,293.3 291.7,293.3 "/>
+</svg>


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
