### PR TITLE
bugfix/97909 - Reset initial slide from shop-the-look drawers

### DIFF
--- a/src/_scripts/sections/shop-the-look.js
+++ b/src/_scripts/sections/shop-the-look.js
@@ -124,7 +124,6 @@ export default class ShopTheLook extends BaseSection {
     this.drawerList.forEach((drawer, i) => {
       const slider = drawer.drawerObject.$el.find(selectors.lookDrawerSlider);
       const swiperSlider = new Swiper(slider, {
-        initialSlide: 1,
         centeredSlides: true,
         loop: false,
         slidesPerView: 1.5,


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
