### PR TITLE
bugfix/36083 - Changed images lazyload method to try to get them loaded when needed

### DIFF
--- a/src/_scripts/sections/shop-the-look.js
+++ b/src/_scripts/sections/shop-the-look.js
@@ -125,7 +125,7 @@ export default class ShopTheLook extends BaseSection {
     this.drawerList.forEach((drawer, i) => {
       const slider = drawer.drawerObject.$el.find(selectors.lookDrawerSlider);
       const swiperSlider = new Swiper(slider.get(0), {
-        modules: [ Navigation, Lazy ],
+        modules: [ Navigation ],
         centeredSlides: true,
         loop: false,
         slidesPerView: 1.5,
@@ -134,12 +134,7 @@ export default class ShopTheLook extends BaseSection {
         navigation: {
           prevEl: '[data-arrow-prev]',
           nextEl: '[data-arrow-next]'
-        },
-        lazy: {
-          enabled: true,
-          loadPrevNextAmount: 3,
-          checkInView: true,
-        },
+        }
       })
       this.drawerList[i].slider = swiperSlider;
     })

--- a/src/snippets/look-drawer.liquid
+++ b/src/snippets/look-drawer.liquid
@@ -33,7 +33,7 @@
             {% endfor %}
             <div class="swiper-slide" data-slide>
               <div class="look-drawer__product-card-image-container frame frame--1x1">
-                <img data-src="{{ current_variant.image | img_url: 'x700' }}" alt="{{ current_variant.image.alt }}" class="swiper-lazy look-drawer__product-card-image frame__inner">
+                <img data-src="{{ current_variant.image | img_url: 'x700' }}" alt="{{ current_variant.image.alt }}" class="lazyload look-drawer__product-card-image frame__inner">
               </div>
 
               <span class="look-drawer__product-card-color">


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
