### PR TITLE
Added a fix to prevent single quotes breaking the data attribute

### DIFF
--- a/src/sections/link-card-slider.liquid
+++ b/src/sections/link-card-slider.liquid
@@ -41,7 +41,7 @@
             {% if bs.enable_mentor_sub %}
               data-toggle-mentor-drawer
               {% assign mentor_info = pages[bs.mentors_page].metafields.custom_fields.mentors_list %}
-              data-mentors-info='{{ mentor_info | json }}'
+              data-mentors-info="{{ mentor_info | json | replace: "'", "&apos;" }}"
               data-mentor-id="{{bs.mentor_id}}"
             {% endif %}></a>
         {% endif %}
@@ -61,7 +61,7 @@
             {% if bs.enable_mentor_sub %}
               data-toggle-mentor-drawer
               {% assign mentor_info = pages[bs.mentors_page].metafields.custom_fields.mentors_list %}
-              data-mentors-info='{{ mentor_info }}'
+              data-mentors-info='{{ mentor_info | json | replace: "'", "&apos;" }}'
               data-mentor-id="{{bs.mentor_id}}"
             {% endif %}
             >


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
