### PR TITLE
bugfix/99243 - Removed trailing zero when having empty size guide content

### DIFF
--- a/src/_scripts/view/drawer/SizeGuideDrawer.js
+++ b/src/_scripts/view/drawer/SizeGuideDrawer.js
@@ -61,7 +61,7 @@ export default function SizeGuideDrawer({data, index}) {
           </a>
         </div>
         <div className="drawer__body-contents fit-guide__body">
-          {data.images && (
+          {data.images.length > 0 && (
             <div className="fit-guide__gallery-container">
               <Swiper
                 modules={[EffectFade, Pagination]}
@@ -89,7 +89,7 @@ export default function SizeGuideDrawer({data, index}) {
             </div>
           }
 
-          {data.sizeList.length && (
+          {data.sizeList.length > 0 && (
             <table className="fit-guide__table responsible-table table-striped">
               <thead>
                 <th></th>
@@ -117,6 +117,7 @@ export default function SizeGuideDrawer({data, index}) {
               </tbody>
             </table>
           )}
+
           {data.boxContent && (
             <div className="blink-box blink-box--dark">
               {data.boxTitle && (


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
