### PR TITLE
Bugfix/69028 - Add missing lazyload class on merge_product images

### DIFF
--- a/src/snippets/product-gallery.liquid
+++ b/src/snippets/product-gallery.liquid
@@ -99,7 +99,7 @@
               {% render 'icon-zoom-out' %}
             </div>
             <div class="swiper-zoom-container">
-              <img data-src="{{ image | image_url }}" alt="{{image.alt}}" class="product-gallery__image">
+              <img data-src="{{ image | image_url }}" alt="{{image.alt}}" class="swiper-lazy product-gallery__image">
               <span class="swiper-lazy-preloader"></span>
             </div>
           </div>


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
