### PR TITLE
feature/21144 - Center featured collection bubbles when not enough slides are populated

### DIFF
--- a/src/_scripts/sections/featuredCategories.js
+++ b/src/_scripts/sections/featuredCategories.js
@@ -31,6 +31,8 @@ export default class HeaderSection extends BaseSection {
       slidesOffsetAfter: 20,
       threshold: 20,
       watchOverflow: true,
+      centerInsufficientSlides: true,
+      observer: true,
       breakpoints: {
         992: {
           slidesOffsetAfter: 40,

--- a/src/_styles/modules/featured-categories.scss
+++ b/src/_styles/modules/featured-categories.scss
@@ -5,7 +5,15 @@
   line-height: 1;
   max-width: 100%;
   position: relative;
+
+  &:not(.swiper-initialized) .swiper-wrapper {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+  }
 }
+
+
 
 .category-capsule {
   border: 2px solid $white;


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
