### PR TITLE
bugfix/32096 Fix mismatching size of empty yotpo star

### DIFF
--- a/src/_styles/components/yotpo/rating-stars.scss
+++ b/src/_styles/components/yotpo/rating-stars.scss
@@ -114,17 +114,11 @@
   @if $yotpo-icon-star-empty {
     .yotpo-icon-default-empty-star,
     .yotpo-icon-empty-star {
-      width: large-vw(20px, 24px) !important;
-      height: large-vw(20px, 24px) !important;
       border: 0px solid transparent;
       margin: 1px;
       display: block;
       float: left;
       position: relative;
-      // margin-right: 2px;
-      // &:last-child {
-      //   margin-right: 0;
-      // }
 
       @include media-breakpoint-down('md') {
         width: 20px !important;


### PR DESCRIPTION
**Links:**
- Jira Ticket: 
- Store preview URL: 
- CMS preview URL: 

**Verify:**
- [ ] Page matches designs (desktop + responsive)
- [ ] All Theme Editor option variations behave correctly (eg. alignment, content variations, how modules work with AND without content populated)
